### PR TITLE
Bump react/promise requirement to 3.0 for PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "plumtreesystems/php-dataloader",
+    "name": "leinonen/php-dataloader",
     "type": "library",
     "description": "Port of Facebook's dataloader to PHP",
     "keywords": ["batch loading", "dataloader", "graphql"],

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Port of Facebook's dataloader to PHP",
     "keywords": ["batch loading", "dataloader", "graphql"],
     "require": {
-        "react/promise": "^2.7.1",
+        "react/promise": "^3.0",
         "react/event-loop": "^1.1.1",
         "php": "^7.4.0|^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "leinonen/php-dataloader",
+    "name": "plumtreesystems/php-dataloader",
     "type": "library",
     "description": "Port of Facebook's dataloader to PHP",
     "keywords": ["batch loading", "dataloader", "graphql"],

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace leinonen\DataLoader;
 
 use React\EventLoop\LoopInterface;
-use function React\Promise\all;
-use React\Promise\ExtendedPromiseInterface;
 use React\Promise\Promise;
+use React\Promise\PromiseInterface;
+
+use function React\Promise\all;
 use function React\Promise\reject;
 use function React\Promise\resolve;
 
@@ -39,7 +40,7 @@ final class DataLoader implements DataLoaderInterface
         callable $batchLoadFunction,
         LoopInterface $loop,
         CacheMapInterface $cacheMap,
-        DataLoaderOptions $options = null
+        ?DataLoaderOptions $options = null
     ) {
         $this->batchLoadFunction = $batchLoadFunction;
         $this->eventLoop = $loop;
@@ -50,7 +51,7 @@ final class DataLoader implements DataLoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function load($key): ExtendedPromiseInterface
+    public function load($key): PromiseInterface
     {
         if ($key === null) {
             throw new \InvalidArgumentException(self::class . '::load must be called with a value, but got null');
@@ -84,7 +85,7 @@ final class DataLoader implements DataLoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadMany(array $keys): ExtendedPromiseInterface
+    public function loadMany(array $keys): PromiseInterface
     {
         return all(
             \array_map(

--- a/src/DataLoader.php
+++ b/src/DataLoader.php
@@ -273,7 +273,7 @@ final class DataLoader implements DataLoaderInterface
     /**
      * Validates the batch promise returned from the batch load function.
      *
-     * @param $batchPromise
+     * @param  $batchPromise
      *
      * @throws DataLoaderException
      */

--- a/src/DataLoaderInterface.php
+++ b/src/DataLoaderInterface.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace leinonen\DataLoader;
 
-use React\Promise\ExtendedPromiseInterface;
-use React\Promise\Promise;
+use React\Promise\PromiseInterface;
 
 interface DataLoaderInterface
 {
@@ -13,11 +12,11 @@ interface DataLoaderInterface
      * Returns a Promise for the value represented by the given key.
      *
      * @param  mixed  $key
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function load($key): ExtendedPromiseInterface;
+    public function load($key): PromiseInterface;
 
     /**
      * Loads multiple keys, promising an array of values.
@@ -30,11 +29,11 @@ interface DataLoaderInterface
      *  });
      *
      * @param  array  $keys
-     * @return ExtendedPromiseInterface
+     * @return PromiseInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function loadMany(array $keys): ExtendedPromiseInterface;
+    public function loadMany(array $keys): PromiseInterface;
 
     /**
      * Clears the value for the given key from the cache if it exists.

--- a/tests/Unit/DataLoaderAbuseTest.php
+++ b/tests/Unit/DataLoaderAbuseTest.php
@@ -6,7 +6,7 @@ use leinonen\DataLoader\CacheMap;
 use leinonen\DataLoader\DataLoader;
 use leinonen\DataLoader\DataLoaderException;
 use PHPUnit\Framework\TestCase;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
 use function React\Promise\resolve;
@@ -20,7 +20,7 @@ class DataLoaderAbuseTest extends TestCase
 
     public function setUp(): void
     {
-        $this->eventLoop = Factory::create();
+        $this->eventLoop = Loop::get();
     }
 
     /**
@@ -162,7 +162,7 @@ class DataLoaderAbuseTest extends TestCase
     public function batch_function_must_return_a_promise_of_an_array_not_null()
     {
         $badLoader = $this->createDataLoader(function ($keys) {
-            return resolve();
+            return resolve(null);
         });
 
         $exception = null;
@@ -210,7 +210,7 @@ class DataLoaderAbuseTest extends TestCase
      * Creates a simple DataLoader.
      *
      * @param $batchLoadFunction
-     * @param  array  $options
+     * @param ?\leinonen\DataLoader\DataLoaderOptions $options
      * @return DataLoader
      */
     private function createDataLoader($batchLoadFunction, $options = null)

--- a/tests/Unit/DataLoaderAbuseTest.php
+++ b/tests/Unit/DataLoaderAbuseTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
+
 use function React\Promise\resolve;
 
 class DataLoaderAbuseTest extends TestCase
@@ -209,8 +210,8 @@ class DataLoaderAbuseTest extends TestCase
     /**
      * Creates a simple DataLoader.
      *
-     * @param $batchLoadFunction
-     * @param ?\leinonen\DataLoader\DataLoaderOptions $options
+     * @param  $batchLoadFunction
+     * @param  ?\leinonen\DataLoader\DataLoaderOptions  $options
      * @return DataLoader
      */
     private function createDataLoader($batchLoadFunction, $options = null)

--- a/tests/Unit/DataLoaderTest.php
+++ b/tests/Unit/DataLoaderTest.php
@@ -777,12 +777,12 @@ class DataLoaderTest extends TestCase
 
         all([
             $identityLoader->load('A'),
-            resolve()->then(function () use ($identityLoader) {
-                resolve()->then(function () use ($identityLoader) {
+            resolve(null)->then(function () use ($identityLoader) {
+                resolve(null)->then(function () use ($identityLoader) {
                     $identityLoader->load('B');
-                    resolve()->then(function () use ($identityLoader) {
+                    resolve(null)->then(function () use ($identityLoader) {
                         $identityLoader->load('C');
-                        resolve()->then(function () use ($identityLoader) {
+                        resolve(null)->then(function () use ($identityLoader) {
                             $identityLoader->load('D');
                         });
                     });

--- a/tests/Unit/DataLoaderTest.php
+++ b/tests/Unit/DataLoaderTest.php
@@ -8,8 +8,9 @@ use leinonen\DataLoader\DataLoaderOptions;
 use PHPUnit\Framework\TestCase;
 use React\EventLoop\Factory;
 use React\EventLoop\LoopInterface;
-use function React\Promise\all;
 use React\Promise\Promise;
+
+use function React\Promise\all;
 use function React\Promise\resolve;
 
 class DataLoaderTest extends TestCase


### PR DESCRIPTION
- DataloaderInterface returns `PromiseInterface`s instead of `ExtendedPromiseInterface`s, as the latter has been removed in react/promise 3.0 ([react/promise 3.0 changelog](https://github.com/reactphp/promise/blob/3.x/CHANGELOG.md#300-2023-07-11))
- Pass value argument to `React\Promise\resolve()` as it has become mandatory
- PHP 8.4+ compatibility: resolve "implicitly nullable parameters are deprecated"